### PR TITLE
現在のページと同じリンクの文字をわかるように設定、ログイン時に文字を収集するモードかどうかわかるようにする。

### DIFF
--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -32,6 +32,8 @@
               <router-link
                 :to="{ name: 'TopIndex' }"
                 class="nav-link active"
+                exact
+                active-class="fw-bold text-danger"
               >
                 ボインボインルーレット
               </router-link>
@@ -74,6 +76,8 @@
                 <router-link
                   :to="{ name: 'ResultIndex' }"
                   class="nav-link active"
+                  exact
+                  active-class="fw-bold text-danger"
                 >
                   集めた言葉
                 </router-link>
@@ -86,6 +90,8 @@
                 <router-link
                   :to="{ name: 'LoginIndex' }"
                   class="nav-link active"
+                  exact
+                  active-class="fw-bold text-danger"
                 >
                   ログイン
                 </router-link>
@@ -116,6 +122,8 @@
                 <router-link
                   :to="{ name: 'RegisterIndex' }"
                   class="nav-link active"
+                  exact
+                  active-class="fw-bold text-danger"
                 >
                   ユーザー登録
                 </router-link>

--- a/app/javascript/components/TheRoulette.vue
+++ b/app/javascript/components/TheRoulette.vue
@@ -1,6 +1,12 @@
 <template>
   <div id="the-roulette">
-    <div class="container-fluid pt-4 pb-4 mt-5 mb-5 shadow rounded">
+    <div class="mt-4 font-gold">
+      <div>ボインボインルーレット</div>
+      <template>
+        <slot name="sub-title" />
+      </template>
+    </div>
+    <div class="container-fluid pt-2 pb-2 mt-3 mb-3 shadow rounded">
       <div class="box">
         <word-box :selected-words="selectedWords" />
       </div>
@@ -84,6 +90,7 @@ export default {
     };
   },
   computed: {
+    ...mapGetters("users", ["authUser"]),
     ...mapGetters("selectedWords", ["selectedWords"]),
     ...mapGetters("randomPickedUp", ["pickedUpWords"]),
     ...mapGetters("voiceSetting", [
@@ -180,6 +187,16 @@ export default {
 </script>
 
 <style scoped>
+.font-gold {
+	font-size: 8vw;
+	text-align: center;
+	line-height: 0.95em;
+	font-weight: bold;
+	color: transparent;
+	background: repeating-linear-gradient(0deg, #B67B03 0.1em, #DAAF08 0.2em, #FEE9A0 0.3em, #DAAF08 0.4em, #B67B03 0.5em); 
+	background-clip: text;
+  -webkit-background-clip: text;
+}
 .container-fluid {
   background: radial-gradient(#ffffff, #fde9ff);
 }

--- a/app/javascript/pages/login/index.vue
+++ b/app/javascript/pages/login/index.vue
@@ -65,7 +65,7 @@ export default {
     async login() {
       try {
         await this.loginUser(this.user);
-        this.$router.push({ name: 'ResultIndex' })
+        this.$router.push({ name: 'TopIndex' })
       } catch (error) {
         console.log(error);
       }

--- a/app/javascript/pages/result/index.vue
+++ b/app/javascript/pages/result/index.vue
@@ -3,11 +3,13 @@
     id="result-index"
     class="container-fluid "
   >
-    <div class="text-center">
-      <h2>
+    <div class="text-center mt-4">
+      <div class="font-gold">
         集めた言葉
-      </h2>
-      <p>合計:{{ resultWords.length }}</p>
+      </div>
+      <p class="mt-2">
+        合計:{{ resultWords.length }}
+      </p>
     </div>
     <div class="row row-cols-4">
       <div
@@ -83,3 +85,16 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.font-gold {
+	font-size: 8vw;
+	text-align: center;
+	line-height: 0.95em;
+	font-weight: bold;
+	color: transparent;
+	background: repeating-linear-gradient(0deg, #B67B03 0.1em, #DAAF08 0.2em, #FEE9A0 0.3em, #DAAF08 0.4em, #B67B03 0.5em); 
+	background-clip: text;
+  -webkit-background-clip: text;
+}
+</style>

--- a/app/javascript/pages/top/index.vue
+++ b/app/javascript/pages/top/index.vue
@@ -1,6 +1,15 @@
 <template>
   <div class="container-fluid text-center">
-    <the-roulette />
+    <the-roulette>
+      <template v-slot:sub-title>
+        <div
+          v-if="authUser"
+          class="mt-2"
+        >
+          収集モード
+        </div>
+      </template>
+    </the-roulette>
     <speech-setting-box />
   </div>
 </template>
@@ -8,11 +17,15 @@
 <script>
 import TheRoulette from '../../components/TheRoulette.vue'
 import SpeechSettingBox from '../../components/SpeechSettingBox.vue'
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
     TheRoulette,
     SpeechSettingBox
+  },
+  computed: {
+    ...mapGetters("users", ["authUser"])
   }
 }
 </script>


### PR DESCRIPTION
# 概要
- v-slotを使用し、サブタイトルを渡す。
  - 他の機能の時に別のサブタイトルを渡せるようにする為。
- Headerに記載されているリンクを `exact` と `active-class` を使用してアクティブ、非アクティブになるように設定