### PR TITLE
iPadOS13以降のsafariに対応した判定メソッドに修正

### DIFF
--- a/app/javascript/components/TheRoulette.vue
+++ b/app/javascript/components/TheRoulette.vue
@@ -160,7 +160,7 @@ export default {
       return judgementResult;
     },
     isSmartPhone() {
-      if(navigator.userAgent.match(/iPhone|iPad|Android.+Mobile/)) {
+      if(navigator.userAgent.toLowerCase().match(/iphone|ipad|android|macintosh/) && 'ontouchend' in document) {
         return true;
       } else {
         return false;

--- a/app/javascript/components/VideoModal.vue
+++ b/app/javascript/components/VideoModal.vue
@@ -63,7 +63,7 @@ export default {
     async showVideoAndSound() {
       try {
         await this.fetchPerformance(this.boinStatus)
-        setTimeout(this.audioPlay, 2000, this.soundUrl)
+        this.audioPlay()
       } catch( error ) {
         console.log(error)
       }


### PR DESCRIPTION
# 概要
- iPadOS13以降のSafariではユーザーエージェントに"iPad"が含まれないため修正
- 演出時のsoundを２秒ずらさずに出すように修正